### PR TITLE
server/hello_rest: Add missing call to resource constructor

### DIFF
--- a/server/hello_rest.py
+++ b/server/hello_rest.py
@@ -24,6 +24,7 @@ from girder.api.rest import Resource
 
 class Hello(Resource):
     def __init__(self):
+        super(Hello, self).__init__()
         self.resourceName = 'hello'
         self.route('GET', (), self.getHello)
 


### PR DESCRIPTION
This commit fixes the following warning:

 WARNING: Resource subclass "Hello" did not call "Resource__init__()" from its constructor.
