### PR TITLE
server/webroot.mako: Explicitly include custom app jss/css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,10 @@ module.exports = function (grunt) {
     var cssDir = pluginDir + '/' + sourceDir + '/stylesheets';
     if (fs.existsSync(cssDir)) {
         var files = {};
-        files[staticDir + '/plugin.min.css'] = [cssDir + '/**/*.styl'];
+        // name this <pluginName>.min.css instead of plugin.min.css
+        // so that girder app won't load <pluginName>, which
+        // should only be loaded as a separate web app running as <pluginName>
+        files[staticDir + '/' + pluginName + '.min.css'] = [cssDir + '/**/*.styl'];
         grunt.config.set('stylus.' + pluginName, {
             files: files
         });
@@ -45,7 +48,10 @@ module.exports = function (grunt) {
     var jsDir = pluginDir + '/' + sourceDir + '/js';
     if (fs.existsSync(jsDir)) {
         var files = {};
-        files[staticDir + '/plugin.min.js'] = [
+        // name this <pluginName>.min.js instead of plugin.min.js
+        // so that girder app won't load <pluginName>, which
+        // should only be loaded as a separate web app running as <pluginName>
+        files[staticDir + '/' + pluginName + '.min.js'] = [
             jsDir + '/init.js',
             staticDir + '/templates.js',
             jsDir + '/view.js',

--- a/server/webroot.mako
+++ b/server/webroot.mako
@@ -15,6 +15,8 @@
         <link rel="stylesheet"
               href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
     % endfor
+    <link rel="stylesheet"
+          href="${staticRoot}/built/plugins/${main_plugin}/${main_plugin}.min.css">
     <link rel="icon"
           type="image/png"
           href="${staticRoot}/img/Girder_Favicon.png">
@@ -28,6 +30,8 @@
       <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js">
       </script>
     % endfor
+    <script src="${staticRoot}/built/plugins/${main_plugin}/${main_plugin}.min.js">
+    </script>
     <script src="${staticRoot}/built/plugins/${main_plugin}/main.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
To avoid the custom app plugin css and js to be included in
the regular girder app, this commit partially reverts 4031d4a.

Adapted from ImageMarkup/isic-archive project (See #8)
